### PR TITLE
Bumped alpine to 3.12.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.12
 
 RUN apk --update -t add keepalived-snmp net-snmp net-snmp-tools curl && \
     rm -f /var/cache/apk/* /tmp/*


### PR DESCRIPTION
Packages installed:
(1/12) Installing keepalived-common (2.0.20-r0)
(2/12) Installing net-snmp-libs (5.8-r3)
(3/12) Installing net-snmp-agent-libs (5.8-r3)
(4/12) Installing libnl (1.1.4-r1)
(5/12) Installing keepalived-snmp (2.0.20-r0)
(6/12) Installing net-snmp (5.8-r3)
(7/12) Installing net-snmp-tools (5.8-r3)
(8/12) Installing ca-certificates (20191127-r2)
(9/12) Installing nghttp2-libs (1.40.0-r0)
(10/12) Installing libcurl (7.69.1-r0)
(11/12) Installing curl (7.69.1-r0)
(12/12) Installing add (20200602.153451)