### PR TITLE
fix: bump Alpine image due to CVE-2020-1971

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.12.7
 
 RUN apk --update -t add keepalived-snmp net-snmp net-snmp-tools curl && \
     rm -f /var/cache/apk/* /tmp/*


### PR DESCRIPTION
This PR:
* ties docker image to specific Alpine release so that we have repetitive builds
* bumps alpine to 3.12.7 to mitigate openssl vulnerability

Alpine 3.12 will be supported until [2022-05-01](https://alpinelinux.org/releases/). Bumping to 3.13 would also cause keepalived to be bumped to v2.2.0 which is a bad idea during the RC stage.

The corresponding Docker image is: `mesosphere/keepalived-snmp:v0.2.1`
